### PR TITLE
Compile oidc auth plugin into binary

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/apimachinery/pkg/watch"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"k8s.io/client-go/tools/clientcmd"
 )
 


### PR DESCRIPTION
This adds the OIDC auth plugin into `stalk`, allowing to use it on oidc-enabled kubeconfigs (e.g. kubeconfigs coming from KKP).