### PR TITLE
documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can download a binary for the [latest release on GitHub](https://github.com/
 or install stalk via Go:
 
 ```bash
-go install go.xrstf.de/stalk
+go install go.xrstf.de/stalk@latest
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ stalk -n kube-system deployments,statefulsets,configmaps,clusterroles
 You can include Cluster-wide resources.
 
 ```bash
-stalk -n kube-system deployments --selector "key=value"
+stalk -n kube-system deployments --labels "key=value"
 ```
 
 A label selector can be given. It will be applied to all given resource kinds.


### PR DESCRIPTION
PR includes two updates to the docs:
1. Use the `--labels` flag. If I see it correctly, the selector flag does not exist anymore and is replaced by the labels flag
2. Add the latest tag for version. Here I have to admit, I find `go install` very confusing. The way I understand it is the following: If you are installing a go pkg for the first time, go install is not allowing you to do so without specifying a version. Afterwards (aka after $GOPATH/pkg/mod is populated), it works without the version. Not sure why they decided to design it this way. Still I think it is best to add the `@latest` in the docs, since most of the users probably will install it for the first time.
	```sh
	❯ go install go.xrstf.de/stalk
	go: 'go install' requires a version when current directory is not in a module
	        Try 'go install go.xrstf.de/stalk@latest' to install the latest version
	```